### PR TITLE
Add window and rootController extension to UIApplication

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.0.13] - 2023-01-09
+
+### Added
+- Add `UIApplication+Window.swift` to get the first `window` and `rootViewController` from the `connectedScenes`
+
 ## [0.0.12] - 2022-12-15
 
 ### Added

--- a/Sources/Qit/Extensions/UIKit/UIApplication/UIApplication+Window.swift
+++ b/Sources/Qit/Extensions/UIKit/UIApplication/UIApplication+Window.swift
@@ -1,0 +1,34 @@
+//
+//  UIApplication+Window.swift
+//  QoQa
+//
+//  Created by Sara Alemanno on 09.01.23.
+//  Copyright © 2021 QoQa Services SA. All rights reserved.
+//
+
+import UIKit
+
+@available(iOS 13, *)
+extension UIApplication {
+
+    /// Returns the first available window
+    var window: UIWindow? {
+        return self
+            .connectedScenes
+            .compactMap { $0 as? UIWindowScene }
+            .flatMap { $0.windows }
+            .first { $0.isKeyWindow }
+    }
+
+    /// Returns the rootViewController or the presentedViewController if displayed
+    var rootViewController: UIViewController? {
+        guard var viewController = window?.rootViewController else { return nil }
+
+        // Get the top presentedController if exists
+        while let presentedViewController = viewController.presentedViewController {
+            viewController = presentedViewController
+        }
+
+        return viewController.presentedViewController ?? viewController
+    }
+}


### PR DESCRIPTION
This PR adds an extension to retrieve the first `window` and the `rootViewController` from the scenes in the app.